### PR TITLE
settings_sbt added

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   sbt_project_directory:
     description: 'relative path to the directory containing your build.sbt, if it is not in the root of your repository'
     default: './'
+  settings_sbt:
+    description: 'The contents of a file that will be written to {sbt_project_directory}/github_action_sbt_settings.sbt'
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 # action.yml
-name: 'SBT Action'
+name: 'SBT Actions'
 author: 'Loki Coyote <lokkju@gmail.com>'
 description: 'SBT build tool action'
 inputs:


### PR DESCRIPTION
Hope this will solve issue #3 and we can use it as follows. 

As per the [documentation](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputs) the committed code should create an environment variable `INPUT_SETTINGS_SBT` which would be available in `entrypoint.sh`

```- name: SBT action test
  id: sbt
  uses: lokkju/github-action-sbt@master
  with:
    commands: test
    settings_sbt: |
      externalResolvers += "maven-releases" at "https://${{secrets.NEXUS_REGISTRY}}/repository/maven-releases/",
      credentials += Credentials("Sonatype Nexus Repository Manager", "${{secrets.NEXUS_REGISTRY}}", "${{secrets.NEXUS_USERNAME}}", "${{secrets.NEXUS_PASSWORD}}")
```

